### PR TITLE
[_] fix: allow escaped

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,17 +1,21 @@
 module.exports = {
   parser: "@typescript-eslint/parser",
-  extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended", "prettier"],
+  extends: [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "prettier",
+  ],
   rules: {
-    quotes: ["error", "single"],
+    quotes: ["error", "single", { avoidEscape: false }],
     semi: ["error", "always"],
     "linebreak-style": ["error", "unix"],
     "max-len": [
       "error",
       {
-        "code": 120,
-        "ignoreComments": true
-      }
+        code: 120,
+        ignoreComments: true,
+      },
     ],
-    "no-console": ["warn"]
+    "no-console": ["warn"],
   },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internxt/eslint-config-internxt",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "main": "index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
In order to use single-quoted character in a string, its needed to either allow double-quoted quotes string or allow to use escaped characters.


Example:
```
'You can\'t do that'
```
This would not be permitted making an auto linter change it to :
```
"You can't do that"
```


https://eslint.org/docs/latest/rules/quotes#single